### PR TITLE
🔒 Fix update dependencies workflow to prevent force-pushing to unrelated branches

### DIFF
--- a/.github/workflows/update_dependencies.yaml
+++ b/.github/workflows/update_dependencies.yaml
@@ -64,16 +64,47 @@ jobs:
             git commit -m "Update dependencies"
             git push origin $BRANCH_NAME
           else
-            # Check for existing PR
-            EXISTING_PR=$(gh pr list --search "Update dependencies in:title is:open" --json headRefName,number -q '.[0]')
+            # Check for existing PR - strict search for exact title and our specific branch pattern
+            EXISTING_PR=$(gh pr list --search "in:title Update dependencies is:open label:automated-dependencies-update" --json headRefName,number,author -q '.[0]')
 
             if [ -n "$EXISTING_PR" ]; then
-              # Update existing PR
+              # Multiple validation checks before using an existing branch
               BRANCH_NAME=$(echo $EXISTING_PR | jq -r .headRefName)
-              git checkout -B $BRANCH_NAME
+              PR_AUTHOR=$(echo $EXISTING_PR | jq -r .author.login)
+              
+              if [[ "$PR_AUTHOR" != "github-actions[bot]" ]]; then
+                echo "Found PR but author is $PR_AUTHOR, not github-actions[bot]. Creating new branch."
+                NEW_BRANCH="update-dependencies-${{ github.run_id }}"
+                git checkout -b $NEW_BRANCH
+                BRANCH_NAME=$NEW_BRANCH
+              elif [[ $BRANCH_NAME != update-dependencies-* ]]; then
+                echo "Found PR but branch $BRANCH_NAME doesn't match our pattern. Creating new branch."
+                NEW_BRANCH="update-dependencies-${{ github.run_id }}"
+                git checkout -b $NEW_BRANCH
+                BRANCH_NAME=$NEW_BRANCH
+              else
+                echo "Found valid PR with branch $BRANCH_NAME by github-actions[bot]. Updating it."
+                git checkout -B $BRANCH_NAME
+              fi
+              
               git add requirements.txt pyproject.toml pdm.lock
               git commit -m "Update dependencies"
               git push -f origin $BRANCH_NAME
+              else
+                # If branch doesn't match our pattern, create a new one
+                NEW_BRANCH="update-dependencies-${{ github.run_id }}"
+                git checkout -b $NEW_BRANCH
+                git add requirements.txt pyproject.toml pdm.lock
+                git commit -m "Update dependencies"
+                git push origin $NEW_BRANCH
+
+                gh pr create \
+                  --title "Update dependencies" \
+                  --body "This PR updates the project dependencies. Please review the changes and merge if everything looks good." \
+                  --base ${{ github.ref_name }} \
+                  --head $NEW_BRANCH \
+                  --label "automated-dependencies-update"
+              fi
             else
               # Create new branch and PR
               NEW_BRANCH="update-dependencies-${{ github.run_id }}"
@@ -86,7 +117,8 @@ jobs:
                 --title "Update dependencies" \
                 --body "This PR updates the project dependencies. Please review the changes and merge if everything looks good." \
                 --base ${{ github.ref_name }} \
-                --head $NEW_BRANCH
+                --head $NEW_BRANCH \
+                --label "automated-dependencies-update"
             fi
           fi
         env:

--- a/.github/workflows/update_dependencies.yaml
+++ b/.github/workflows/update_dependencies.yaml
@@ -56,12 +56,28 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
 
+          # Function to commit changes
+          commit_changes() {
+            git add requirements.txt pyproject.toml pdm.lock
+            git commit -m "Update dependencies"
+          }
+
+          # Function to create PR
+          create_pr() {
+            local BRANCH=$1
+            gh pr create \
+              --title "Update dependencies" \
+              --body "This PR updates the project dependencies. Please review the changes and merge if everything looks good." \
+              --base ${{ github.ref_name }} \
+              --head $BRANCH \
+              --label "automated-dependencies-update"
+          }
+
           if [ -n "${{ inputs.pr_branch }}" ]; then
             # Push to existing branch
             BRANCH_NAME=$(echo ${{ inputs.pr_branch }} | cut -d'/' -f 3)
             git checkout $BRANCH_NAME
-            git add requirements.txt pyproject.toml pdm.lock
-            git commit -m "Update dependencies"
+            commit_changes
             git push origin $BRANCH_NAME
           else
             # Check for existing PR - strict search for exact title and our specific branch pattern
@@ -72,54 +88,28 @@ jobs:
               BRANCH_NAME=$(echo $EXISTING_PR | jq -r .headRefName)
               PR_AUTHOR=$(echo $EXISTING_PR | jq -r .author.login)
               
-              if [[ "$PR_AUTHOR" != "github-actions[bot]" ]]; then
-                echo "Found PR but author is $PR_AUTHOR, not github-actions[bot]. Creating new branch."
-                NEW_BRANCH="update-dependencies-${{ github.run_id }}"
-                git checkout -b $NEW_BRANCH
-                BRANCH_NAME=$NEW_BRANCH
-              elif [[ $BRANCH_NAME != update-dependencies-* ]]; then
-                echo "Found PR but branch $BRANCH_NAME doesn't match our pattern. Creating new branch."
-                NEW_BRANCH="update-dependencies-${{ github.run_id }}"
-                git checkout -b $NEW_BRANCH
-                BRANCH_NAME=$NEW_BRANCH
-              else
+              if [[ "$PR_AUTHOR" == "github-actions[bot]" && "$BRANCH_NAME" == update-dependencies-* ]]; then
                 echo "Found valid PR with branch $BRANCH_NAME by github-actions[bot]. Updating it."
                 git checkout -B $BRANCH_NAME
-              fi
-              
-              git add requirements.txt pyproject.toml pdm.lock
-              git commit -m "Update dependencies"
-              git push -f origin $BRANCH_NAME
+                commit_changes
+                git push -f origin $BRANCH_NAME
               else
-                # If branch doesn't match our pattern, create a new one
+                echo "Found PR but it's not from our bot or wrong branch pattern. Creating new branch."
                 NEW_BRANCH="update-dependencies-${{ github.run_id }}"
                 git checkout -b $NEW_BRANCH
-                git add requirements.txt pyproject.toml pdm.lock
-                git commit -m "Update dependencies"
+                commit_changes
                 git push origin $NEW_BRANCH
-
-                gh pr create \
-                  --title "Update dependencies" \
-                  --body "This PR updates the project dependencies. Please review the changes and merge if everything looks good." \
-                  --base ${{ github.ref_name }} \
-                  --head $NEW_BRANCH \
-                  --label "automated-dependencies-update"
+                create_pr $NEW_BRANCH
               fi
             else
-              # Create new branch and PR
+              echo "No existing PR found. Creating new branch and PR."
               NEW_BRANCH="update-dependencies-${{ github.run_id }}"
               git checkout -b $NEW_BRANCH
-              git add requirements.txt pyproject.toml pdm.lock
-              git commit -m "Update dependencies"
+              commit_changes
               git push origin $NEW_BRANCH
-
-              gh pr create \
-                --title "Update dependencies" \
-                --body "This PR updates the project dependencies. Please review the changes and merge if everything looks good." \
-                --base ${{ github.ref_name }} \
-                --head $NEW_BRANCH \
-                --label "automated-dependencies-update"
+              create_pr $NEW_BRANCH
             fi
+          fi
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR fixes a critical issue in the update dependencies workflow where it could potentially force-push to unrelated branches.

Changes:
1. Add specific label "automated-dependencies-update" to all PRs created by this workflow
2. Search for PRs using this label as an additional filter
3. Add strict validation of the PR author (must be "github-actions[bot]")
4. Add strict validation of the branch name pattern (must start with "update-dependencies-")
5. Create a new branch if any of these validations fail
6. Add more descriptive echo statements to help debug workflow actions

These changes prevent the workflow from force-pushing to branches that were not created by itself, avoiding situations like the one where it force-pushed to "ci/deps-reuse-branch" that was created by a legitimate developer.