### PR TITLE
✨ Add automatic creation of dependencies update label

### DIFF
--- a/.github/workflows/update_dependencies.yaml
+++ b/.github/workflows/update_dependencies.yaml
@@ -50,6 +50,19 @@ jobs:
         run: |
           git diff --exit-code --quiet requirements.txt || echo "changed=true" >> $GITHUB_OUTPUT
 
+      - name: Create required label if not exists
+        run: |
+          # Check if label exists
+          LABEL_EXISTS=$(gh label list | grep "automated-dependencies-update" || true)
+          if [ -z "$LABEL_EXISTS" ]; then
+            echo "Creating automated-dependencies-update label..."
+            gh label create "automated-dependencies-update" \
+              --color "2DA44E" \
+              --description "Automated PR for updating project dependencies"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Handle dependency updates
         if: steps.git-check.outputs.changed == 'true'
         run: |


### PR DESCRIPTION
This PR adds automatic creation of the `automated-dependencies-update` label if it does not exist. This ensures the update dependencies workflow will not fail when trying to add the label to PRs.

Changes:
- Add new step to check if label exists
- Create label with green color and descriptive text if it does not exist
- Add proper error handling for label check