### PR TITLE
🐛 Remove extra fi in update dependencies workflow

### DIFF
--- a/.github/workflows/update_dependencies.yaml
+++ b/.github/workflows/update_dependencies.yaml
@@ -123,6 +123,5 @@ jobs:
               create_pr $NEW_BRANCH
             fi
           fi
-          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix syntax error by removing extra `fi` statement at the end of the workflow file.